### PR TITLE
chore: added max height to anime backdrop, changed read more button to follow collapsible description

### DIFF
--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -15,7 +15,7 @@ function RootRoute() {
       <div className="max-w-[1440px] mx-auto">
         <ScrollRestoration />
         <Outlet />
-        <TanStackRouterDevtools />
+        {/* <TanStackRouterDevtools /> */}
       </div>
     </div>
   );

--- a/src/routes/anime/-AnimeHeroComponent.tsx
+++ b/src/routes/anime/-AnimeHeroComponent.tsx
@@ -55,19 +55,19 @@ export default function AnimeHeroComponent({
   }, []);
 
   return (
-    <div className="relative flex justify-center w-full pt-32 pb-12 text-sm">
-      <div className="absolute inset-0 w-dvw left-1/2 ml-[-50vw]">
+    <div className="relative flex justify-center w-full">
+      <div className="absolute inset-0 w-dvw left-1/2 ml-[-50vw] max-h-[600px]">
         <div className="absolute bg-black/60 size-full backdrop-blur-sm"></div>
         <div className="absolute bg-gradient-to-t from-darkBg from-[percentage:0%_1%] via-transparent to-transparent size-full"></div>
         <img src={cover ?? image} className="object-cover size-full" />
       </div>
-      <div className="flex justify-center w-full gap-16">
-        <div className="aspect-[3/4] h-[350px] rounded-xl overflow-hidden z-10">
-          <img src={image} />
+      <div className="flex w-full gap-16 px-24 pt-32 pb-12">
+        <div className="aspect-[3/4] h-[320px] rounded-xl overflow-hidden z-10">
+          <img src={image} className="object-cover"/>
         </div>
-        <div className="max-w-[65%] z-10 relative">
+        <div className="relative z-10 flex-1">
           <p className="text-3xl font-bold">{title}</p>
-          <div className="flex flex-col justify-center w-[70%] gap-4">
+          <div className="relative flex flex-col w-[70%] gap-4">
             <div className="flex items-center gap-4 mt-5">
               <div
                 style={{
@@ -83,12 +83,14 @@ export default function AnimeHeroComponent({
                   style={{
                     width: `${starsFillWidthPercentage}%`,
                   }}
-                  className={`absolute bg-amber-400 size-full`}
+                  className={`absolute bg-amber-400 h-full`}
                 ></div>
               </div>
               <p className="text-lg font-semibold">
                 <span className="text-mainAccent">
-                  {rating ? (0.05 * (rating * 10)).toFixed(1) : "?"}
+                  {rating
+                    ? `${(0.05 * (rating * 10)).toString().split(".")[1].length > 1 ? (0.05 * (rating * 10)).toFixed(2) : (0.05 * (rating * 10)).toFixed(1)}`
+                    : "?"}
                 </span>
                 /5
               </p>
@@ -106,7 +108,7 @@ export default function AnimeHeroComponent({
                 <div className="flex gap-2">
                   <p className="text-gray-400">Status:</p>
                   <p
-                    className={`${status === "RELEASING" ? "text-green-500" : "text-blue-500"}`}
+                    className={`${status === "RELEASING" ? "text-green-500" : "text-blue-500"} font-semibold`}
                   >
                     {status}
                   </p>
@@ -128,9 +130,9 @@ export default function AnimeHeroComponent({
                 </div>
               </div>
             </div>
-            <div className="flex gap-5 my-4">
+            <div className="flex gap-5 my-3">
               <motion.button
-                whileHover={{ scale: 1.02 }}
+                whileHover={{ scale: 1.03 }}
                 transition={{ duration: 0.2 }}
                 className="flex items-center gap-2 px-5 py-2 rounded-full bg-mainAccent"
               >
@@ -138,7 +140,7 @@ export default function AnimeHeroComponent({
                 <p className="font-medium">Play Now</p>
               </motion.button>
               <motion.button
-                whileHover={{ scale: 1.02 }}
+                whileHover={{ scale: 1.03 }}
                 transition={{ duration: 0.2 }}
                 className="flex items-center gap-2 px-5 py-2 bg-black rounded-full"
               >
@@ -169,27 +171,37 @@ export default function AnimeHeroComponent({
                 {`${description ? description.replace(/<[^>]*>/g, "") : "No Description"}`}
               </p>
             </motion.div>
-          </div>
-          {descriptionHeight > 80 && (
-            <button
-              onClick={() => setReadMore(!readMore)}
-              className="absolute left-0 flex gap-3 -bottom-8"
-            >
-              <p className="text-gray-400">
-                {readMore ? "Read Less" : "Read More"}
-              </p>
+            {descriptionHeight > 80 && (
               <motion.div
                 animate={{
-                  rotate: readMore ? -180 : 0,
+                  height: readMore ? `${descriptionHeight}px` : "80px",
                 }}
                 transition={{
-                  duration: 0.5,
+                  duration: 0.2,
                 }}
+                className="absolute w-full -bottom-3"
               >
-                <ChevronDown stroke="#9ca3af" />
+                <button
+                  onClick={() => setReadMore(!readMore)}
+                  className="absolute left-0 flex gap-3 -bottom-6"
+                >
+                  <p className="text-gray-400">
+                    {readMore ? "Read Less" : "Read More"}
+                  </p>
+                  <motion.div
+                    animate={{
+                      rotate: readMore ? -180 : 0,
+                    }}
+                    transition={{
+                      duration: 0.5,
+                    }}
+                  >
+                    <ChevronDown stroke="#9ca3af" />
+                  </motion.div>
+                </button>
               </motion.div>
-            </button>
-          )}
+            )}
+          </div>
         </div>
       </div>
     </div>

--- a/src/routes/anime/-HomeHeader.tsx
+++ b/src/routes/anime/-HomeHeader.tsx
@@ -26,7 +26,7 @@ export default function HomeHeader() {
       className={`fixed left-1/2 ml-[-50vw] w-dvw z-[999999] ${isScrolledDown ? "bg-darkBg/80" : ""} transition-all duration-300`}
     >
       <div
-        className={`flex items-center justify-between mx-auto w-[1440px] py-4 transition-all duration-300`}
+        className={`flex items-center justify-between mx-auto px-24 max-w-[1440px] py-4 transition-all duration-300`}
       >
         <Menu size={24} color="white" />
         <div className="flex items-center gap-12 text-sm">

--- a/src/routes/anime/-TrendingAnimesHeroCarousel.tsx
+++ b/src/routes/anime/-TrendingAnimesHeroCarousel.tsx
@@ -16,7 +16,7 @@ export default function TrendingAnimesHeroCarousel({
   animeList,
 }: TrendingAnimeCarouselProps) {
   return (
-    <Carousel className="w-dvw">
+    <Carousel>
       <CarouselContent>
         {animeList.map((anime, i) => {
           return (

--- a/src/routes/anime/-TrendingCarouselItem.tsx
+++ b/src/routes/anime/-TrendingCarouselItem.tsx
@@ -11,7 +11,7 @@ type AnimeHeroComponentProps = {
   year?: number;
   type?: string;
   trendingRank?: number;
-  genres?: string[];
+  genres: string[];
 };
 
 export default function TrendingCarouselItem({
@@ -20,7 +20,6 @@ export default function TrendingCarouselItem({
   title,
   description,
   id,
-  //   year,
   type,
   trendingRank,
   genres,
@@ -28,61 +27,73 @@ export default function TrendingCarouselItem({
   const navigate = useNavigate();
 
   return (
-    <div className="relative flex justify-center w-[1440px] mx-auto pt-32 pb-12">
-      <div className="flex w-full gap-16 pl-24">
-        <div className="aspect-[3/4] h-[350px] rounded-xl overflow-hidden z-10">
-          <img src={image} />
-        </div>
-        <div className="max-w-[65%] z-10 relative flex flex-col justify-center gap-6">
-          <div className="space-y-2">
-            <p className="text-lg">
-              <span className="text-xl font-semibold text-mainAccent">
-                #{trendingRank}
-              </span>{" "}
-              in trending
-            </p>
-            <p className="text-4xl font-bold line-clamp-2">{title}</p>
+    <div className="flex justify-center w-full h-[80dvh] max-h-[600px] items-center pt-20">
+      <div className="relative flex justify-center w-[1440px] px-24">
+        <div className="flex items-center w-full gap-16">
+          <div className="aspect-[3/4] h-[300px] rounded-xl overflow-hidden z-10">
+            <img src={image} className="object-cover size-full" />
           </div>
-          <div className="flex flex-col justify-center w-[75%] gap-4">
-            <div className="relative overflow-hidden">
-              <p className="line-clamp-3">
-                {`${description ? description.replace(/<[^>]*>/g, "") : "No Description"}`}
+          <div className="relative z-10 flex-1">
+            <div className="relative flex flex-col w-[70%] gap-4">
+              <p className="text-lg">
+                <span className="text-2xl font-bold text-mainAccent">
+                  #{trendingRank}
+                </span>{" "}
+                in trending
               </p>
-            </div>
-            <div className="flex gap-5 my-4">
-              <motion.button
-                whileHover={{ scale: 1.02 }}
-                transition={{ duration: 0.2 }}
-                onClick={() => {
-                  navigate({
-                    to: "/anime/info/$animeId",
-                    params: {
-                      animeId: id,
-                    },
-                    state: {
-                      animeInfoPageNavigationState: {
-                        image: image,
-                        cover: cover,
-                        genres: genres!,
-                        description: description,
-                        type: type!,
+              <p className="text-3xl font-bold">{title}</p>
+              <p className="text-gray-400 line-clamp-3">
+                {`${description ? description.replace(/<[^>]*>/g, "") : "No Description"}`}
+                {/* <div className="flex text-lg">
+                  {genres.map((genre, i) => {
+                    return (
+                      <div
+                        className={`flex items-center text-gray-400 gap-2 ${i !== 0 ? "ml-2" : ""}`}
+                      >
+                        <p>{genre}</p>
+                        {i !== genres.length - 1 && (
+                          <div className="bg-gray-400 rounded-full size-1"></div>
+                        )}
+                      </div>
+                    );
+                  })}
+                </div> */}
+              </p>
+              <div className="flex gap-5 my-4">
+                <motion.button
+                  whileHover={{ scale: 1.03 }}
+                  transition={{ duration: 0.2 }}
+                  onClick={() => {
+                    navigate({
+                      to: "/anime/info/$animeId",
+                      params: {
+                        animeId: id,
                       },
-                    },
-                  });
-                }}
-                className="flex items-center gap-2 px-5 py-2 rounded-full bg-mainAccent"
-              >
-                <Play size={20} />
-                <p className="font-medium">Play Now</p>
-              </motion.button>
-              <motion.button
-                whileHover={{ scale: 1.02 }}
-                transition={{ duration: 0.2 }}
-                className="flex items-center gap-2 px-5 py-2 bg-black rounded-full"
-              >
-                <Bookmark size={20} />
-                <p className="font-medium">Add to List</p>
-              </motion.button>
+                      state: {
+                        animeInfoPageNavigationState: {
+                          image: image,
+                          cover: cover,
+                          genres: genres!,
+                          description: description,
+                          type: type!,
+                        },
+                      },
+                    });
+                  }}
+                  className="flex items-center gap-2 px-5 py-2 rounded-full bg-mainAccent"
+                >
+                  <Play size={20} />
+                  <p className="font-medium">Play Now</p>
+                </motion.button>
+                <motion.button
+                  whileHover={{ scale: 1.03 }}
+                  transition={{ duration: 0.2 }}
+                  className="flex items-center gap-2 px-5 py-2 bg-black rounded-full"
+                >
+                  <Bookmark size={20} />
+                  <p className="font-medium">Add to List</p>
+                </motion.button>
+              </div>
             </div>
           </div>
         </div>

--- a/src/routes/anime/index.tsx
+++ b/src/routes/anime/index.tsx
@@ -13,11 +13,7 @@ export const Route = createFileRoute("/anime/")({
 
 function Home() {
   const { data: trendingAnimes, isLoading: isTrendingAnimesLoading } =
-    useFetchTrendingAnime(5, 1);
-  const {
-    data: trendingAnimePageTwo,
-    isLoading: isTrendingAnimePageTwoLoading,
-  } = useFetchTrendingAnime(12, 1);
+    useFetchTrendingAnime(17, 1);
   const { data: popularAnimes, isLoading: isPopularAnimesLoading } =
     useFetchPopularAnimes(12);
 
@@ -25,33 +21,37 @@ function Home() {
     useFetchTopRatedAnime(12);
 
   if (
-    isTrendingAnimePageTwoLoading ||
+    // isTrendingAnimePageTwoLoading ||
     isTrendingAnimesLoading ||
     isPopularAnimesLoading ||
     isTopRatedAnimesLoading
   ) {
     return (
       <div className="grid text-2xl text-white bg-darkBg h-dvh place-items-center">
-        <p>Loading <span className="font-semibold text-mainAccent">AzuraAnime</span></p>
+        <p>
+          Loading{" "}
+          <span className="font-semibold text-mainAccent">AzuraAnime</span>
+        </p>
       </div>
     );
   }
 
   if (
     trendingAnimes &&
-    trendingAnimePageTwo &&
+    // trendingAnimePageTwo &&
     popularAnimes &&
     topRatedAnimes
   ) {
-    
     return (
       <div className="flex flex-col items-center w-full">
         <div className="w-dvw">
-          <TrendingAnimesHeroCarousel animeList={trendingAnimes.results} />
+          <TrendingAnimesHeroCarousel
+            animeList={trendingAnimes.results.slice(0, 5)}
+          />
         </div>
         <div className="pb-24 space-y-10">
           <AnimeCategorySection
-            animeList={trendingAnimePageTwo.results}
+            animeList={trendingAnimes.results.slice(5)}
             categoryName="Trending Anime"
           />
           <AnimeCategorySection

--- a/src/routes/anime/info/$animeId/-EpisodeCard.tsx
+++ b/src/routes/anime/info/$animeId/-EpisodeCard.tsx
@@ -1,20 +1,31 @@
 import { Link } from "@tanstack/react-router";
 
 type EpisodeCardProps = {
+  id: string;
   number: number;
   title: string;
   image: string;
+  type: string;
 };
 
 export default function EpisodeCard({
+  id,
   number,
   title,
   image,
+  type,
 }: EpisodeCardProps) {
   return (
-    <Link className="relative flex flex-col gap-2 aspect-[4/2.7] group">
+    <div
+      onClick={() => console.log(id)}
+      className="relative flex flex-col gap-2 
+    aspect-[4/2.7] 
+    group"
+    >
       <div className="relative flex-1">
-        <div className="absolute z-20 px-2 py-1 bottom-1 left-1 text-sm text-[#E0E0E0] rounded-lg bg-black/60">Episode {number}</div>
+        <div className="absolute z-20 px-2 py-1 bottom-1 left-1 text-sm text-[#E0E0E0] rounded-lg bg-black/60">
+          {type === "MOVIE" ? `MOVIE` : `Episode ${number}`}
+        </div>
         <div className="absolute z-10 grid transition-all rounded-lg opacity-0 place-items-center size-full bg-mainAccent/40 group-hover:opacity-100">
           <div className="grid bg-white rounded-full size-12 place-items-center">
             <svg
@@ -35,8 +46,14 @@ export default function EpisodeCard({
       </div>
       <div className="text-sm">
         {/* <p className="text-white">{`Episode ${number}`}</p> */}
-        <p className="line-clamp-1">EP {number}</p>
+        <p className="line-clamp-1">
+          {type === "MOVIE"
+            ? "FULL"
+            : title === `Episode ${number}`
+              ? `EP ${number}`
+              : title}
+        </p>
       </div>
-    </Link>
+    </div>
   );
 }

--- a/src/routes/anime/info/$animeId/-Episodes.tsx
+++ b/src/routes/anime/info/$animeId/-Episodes.tsx
@@ -8,11 +8,13 @@ import { chunkEpisodes } from "@/utils/functions/reusable_functions";
 type EpisodesProps = {
   episodes?: Episode[] | null;
   defaultEpisodeImage: string;
+  type: string
 };
 
 export default function Episodes({
   episodes,
   defaultEpisodeImage,
+  type
 }: EpisodesProps) {
   const [chunkedEpisodes, setChunkedEpisodes] = useState<EpisodeChunk[]>();
 
@@ -40,7 +42,9 @@ export default function Episodes({
           {episodes.map((episode, i) => {
             return (
               <EpisodeCard
-                image={episode.img ?? defaultEpisodeImage}
+                type={type}
+                id={episode.id}
+                image={episode.image ?? defaultEpisodeImage}
                 title={episode.title}
                 number={episode.number}
                 key={i}

--- a/src/routes/anime/info/$animeId/index.tsx
+++ b/src/routes/anime/info/$animeId/index.tsx
@@ -69,6 +69,9 @@ function AnimeInfo() {
 
     if (gogoAnimeEpisodes) {
       epsToBeRendered = gogoAnimeEpisodes.map((ep, i) => {
+        //get episode ids from gogoanime,
+        //get episode titles from zoro,
+        //get episode images from animepahe
         return {
           id: ep.id,
           number: ep.number,
@@ -83,12 +86,13 @@ function AnimeInfo() {
               : ep.title,
         };
       });
+
     } else {
       epsToBeRendered = null;
     }
 
     return (
-      <div className="relative max-w-full">
+      <div className="w-full">
         <AnimeHeroComponent
           title={animeInfoAnify.title.english}
           cover={animeInfoAnify.bannerImage}
@@ -105,11 +109,12 @@ function AnimeInfo() {
           }
           status={animeInfoAnify.status}
           totalEpisodes={animeInfoAnify.totalEpisodes}
-          type={animeInfoPageNavigationState?.type ?? animeInfoAnify.format}
+          type={animeInfoPageNavigationState?.type ?? animeInfoAnilist?.type}
           year={animeInfoAnify.year}
           rating={animeInfoAnify.rating.anilist ?? null}
         />
         <Episodes
+          type={animeInfoAnify.format}
           episodes={epsToBeRendered}
           defaultEpisodeImage={
             animeInfoPageNavigationState?.cover ?? animeInfoAnify.coverImage

--- a/src/routes/anime/route.tsx
+++ b/src/routes/anime/route.tsx
@@ -7,7 +7,7 @@ export const Route = createFileRoute("/anime")({
 
 function HomeLayout() {
   return (
-    <div className="text-[#f6f4f4] font-montserrat bg-darkBg w-full">
+    <div className="text-[#f6f4f4] font-montserrat w-full">
       <HomeHeader />
       <Outlet />
     </div>


### PR DESCRIPTION
#5 

In this commit I:

- added max height to anime backdrop
- AnimeHeroComponent: 
---- changed read more button to be positioned below and follow the collapsible description when folding/unfolding by making it into an absolute motion.div positioned at the bottom, and animates the height based on the changing of the description height
---- transferred padding of the hero content to the direct parent of the content instead of the div parent of the component
---- modified AnimeHeroComponent to display two decimal points for rating if the score from the api is with two decimal points, and 1 decimal point otherwise.
- changed fetching of trending anime, now does one fetch of 17 trending animes instead of separate fetches for carousel and trending category section. Divided it to the carousel (5 animes)  and trending category section (12 animes)
- changed EpisodeCard props to take type and id
- modified EpisodeCard to display MOVIE instead of Episode when the type is movie