### PR TITLE
feat: responsive anime homepage

### DIFF
--- a/src/components/ui/custom-carousel.tsx
+++ b/src/components/ui/custom-carousel.tsx
@@ -5,7 +5,7 @@ import useEmblaCarousel, {
 import { ChevronLeft, ChevronRight } from "lucide-react";
 
 import { cn } from "@/lib/utils";
-import { Button } from "./button";
+import { Button, ButtonProps } from "./button";
 
 type CarouselApi = UseEmblaCarouselType[1];
 type UseCarouselParameters = Parameters<typeof useEmblaCarousel>;
@@ -192,93 +192,145 @@ const CarouselItem = React.forwardRef<
 });
 CarouselItem.displayName = "CarouselItem";
 
+type CarouselActionAdditionalProps = {
+  carouselType: "category-carousel" | "hero-carousel";
+};
+
 const CarouselPrevious = React.forwardRef<
   HTMLButtonElement,
-  React.ComponentProps<typeof Button>
->(({ className, variant = "outline", size = "icon", ...props }, ref) => {
-  const { orientation, scrollPrev, canScrollPrev } = useCarousel();
+  Omit<ButtonProps, keyof CarouselActionAdditionalProps> &
+    CarouselActionAdditionalProps
+>(
+  (
+    { className, variant = "outline", size = "icon", carouselType, ...props },
+    ref
+  ) => {
+    const { orientation, scrollPrev, canScrollPrev } = useCarousel();
 
-  const [isHovered, setIsHovered] = React.useState(false);
+    const [isHovered, setIsHovered] = React.useState(false);
 
-  const handleMouseEnter = () => {
-    setIsHovered(true);
-  };
+    const handleMouseEnter = () => {
+      setIsHovered(true);
+    };
 
-  const handleMouseLeave = () => {
-    setIsHovered(false);
-  };
+    const handleMouseLeave = () => {
+      setIsHovered(false);
+    };
 
-  return (
-    <Button
-      onMouseEnter={handleMouseEnter}
-      onMouseLeave={handleMouseLeave}
-      ref={ref}
-      variant={variant}
-      size={size}
-      className={cn(
-        "absolute rounded-full size-14",
-        !canScrollPrev ? "hidden" : "",
-        orientation === "horizontal"
-          ? "-left-12 top-1/2 -translate-y-1/2"
-          : "-top-12 left-1/2 -translate-x-1/2 rotate-90",
-        className
-      )}
-      disabled={!canScrollPrev}
-      onClick={scrollPrev}
-      {...props}
-    >
-      <ChevronLeft
-        className={`size-12 ${isHovered ? "" : "opacity-70"}`}
-        color={isHovered ? "white" : "#c026d3"}
-      />
-      <span className="sr-only">Previous slide</span>
-    </Button>
-  );
-});
+    if (carouselType === "hero-carousel") {
+      return (
+        <Button
+          onMouseEnter={handleMouseEnter}
+          onMouseLeave={handleMouseLeave}
+          ref={ref}
+          variant={variant}
+          size={size}
+          className={cn(
+            "absolute rounded-full mobile-l:p-1 md:p-2 box-content",
+            !canScrollPrev ? "hidden" : "",
+            orientation === "horizontal"
+              ? "-left-12 top-1/2 -translate-y-1/2"
+              : "-top-12 left-1/2 -translate-x-1/2 rotate-90",
+            className
+          )}
+          disabled={!canScrollPrev}
+          onClick={scrollPrev}
+          {...props}
+        >
+          <ChevronLeft
+            className={`size-8 md:size-10 xl:size-12 ${isHovered ? "" : "opacity-70"}`}
+            color={isHovered ? "white" : "#c026d3"}
+          />
+          <span className="sr-only">Previous slide</span>
+        </Button>
+      );
+    }
+
+    return (
+      <button
+        onClick={scrollPrev}
+        className={cn(
+          "absolute h-full w-8 flex items-center justify-center group",
+          !canScrollPrev ? "hidden" : "",
+          orientation === "horizontal"
+            ? "-left-12 top-1/2 -translate-y-1/2"
+            : "-top-12 left-1/2 -translate-x-1/2 rotate-90",
+          className
+        )}
+      >
+        <ChevronLeft className="size-8 stroke-white group-hover:stroke-mainAccent" />
+      </button>
+    );
+  }
+);
 CarouselPrevious.displayName = "CarouselPrevious";
 
 const CarouselNext = React.forwardRef<
   HTMLButtonElement,
-  React.ComponentProps<typeof Button>
->(({ className, variant = "outline", size = "icon", ...props }, ref) => {
-  const { orientation, scrollNext, canScrollNext } = useCarousel();
-  const [isHovered, setIsHovered] = React.useState(false);
+  Omit<ButtonProps, keyof CarouselActionAdditionalProps> &
+    CarouselActionAdditionalProps
+>(
+  (
+    { className, variant = "outline", size = "icon", carouselType, ...props },
+    ref
+  ) => {
+    const { orientation, scrollNext, canScrollNext } = useCarousel();
+    const [isHovered, setIsHovered] = React.useState(false);
 
-  const handleMouseEnter = () => {
-    setIsHovered(true);
-  };
+    const handleMouseEnter = () => {
+      setIsHovered(true);
+    };
 
-  const handleMouseLeave = () => {
-    setIsHovered(false);
-  };
+    const handleMouseLeave = () => {
+      setIsHovered(false);
+    };
 
-  return (
-    <Button
-      onMouseEnter={handleMouseEnter}
-      onMouseLeave={handleMouseLeave}
-      ref={ref}
-      variant={variant}
-      size={size}
-      className={cn(
-        "absolute size-14 rounded-full",
-        !canScrollNext ? "hidden" : "",
-        orientation === "horizontal"
-          ? "-right-12 top-1/2 -translate-y-1/2"
-          : "-bottom-12 left-1/2 -translate-x-1/2 rotate-90",
-        className
-      )}
-      disabled={!canScrollNext}
-      onClick={scrollNext}
-      {...props}
-    >
-      <ChevronRight
-        className={`size-12 ${isHovered ? "" : "opacity-70"}`}
-        color={isHovered ? "white" : "#c026d3"}
-      />
-      <span className="sr-only">Next slide</span>
-    </Button>
-  );
-});
+    if (carouselType === "hero-carousel") {
+      return (
+        <Button
+          onMouseEnter={handleMouseEnter}
+          onMouseLeave={handleMouseLeave}
+          ref={ref}
+          variant={variant}
+          size={size}
+          className={cn(
+            "absolute box-content mobile-l:p-1 md:p-2 rounded-full",
+            !canScrollNext ? "hidden" : "",
+            orientation === "horizontal"
+              ? "-right-12 top-1/2 -translate-y-1/2"
+              : "-bottom-12 left-1/2 -translate-x-1/2 rotate-90",
+            className
+          )}
+          disabled={!canScrollNext}
+          onClick={scrollNext}
+          {...props}
+        >
+          <ChevronRight
+            className={`size-8 md:size-10 xl:size-12 ${isHovered ? "" : "opacity-70"}`}
+            color={isHovered ? "white" : "#c026d3"}
+          />
+          <span className="sr-only">Next slide</span>
+        </Button>
+      );
+    }
+
+    return (
+      <button
+        onClick={scrollNext}
+        className={cn(
+          "absolute h-full w-8 flex items-center justify-center group",
+          !canScrollNext ? "hidden" : "",
+          orientation === "horizontal"
+            ? "-right-12 top-1/2 -translate-y-1/2"
+            : "-bottom-12 left-1/2 -translate-x-1/2 rotate-90",
+          className
+        )}
+      >
+        <ChevronRight className="size-8 stroke-white group-hover:stroke-mainAccent" />
+      </button>
+    );
+  }
+);
 CarouselNext.displayName = "CarouselNext";
 
 export {

--- a/src/index.css
+++ b/src/index.css
@@ -81,3 +81,13 @@ html,body {
    overflow-x-hidden
    bg-[#100c14]
 }
+
+.hidden-scrollbar{
+  scrollbar-width: none; /* For Firefox */
+  -ms-overflow-style: none;  /* For Internet Explorer and Edge */
+  scroll-behavior: smooth;
+}
+
+.hidden-scrollbar::-webkit-scrollbar{
+  display: none; /* For Chrome, Safari, and Opera */
+}

--- a/src/routes/anime/$animeId/-EpisodeCard.tsx
+++ b/src/routes/anime/$animeId/-EpisodeCard.tsx
@@ -19,7 +19,7 @@ export default function EpisodeCard({
       className="relative flex flex-col gap-2 text-xs md:text-sm aspect-[6/5] mobile-m:aspect-[4/3] lg:aspect-[4/2.7] group"
     >
       <div className="relative flex-1">
-        <div className="absolute font-medium z-20 px-2 py-[3px] bottom-1 left-1 text-[#E0E0E0] rounded-md bg-black/60">
+        <div className="absolute font-semibold z-20 px-2 py-[3px] bottom-1 left-1 text-[#E0E0E0] rounded-md bg-black/60">
           {type === "MOVIE" ? `MOVIE` : `Episode ${number}`}
         </div>
         <div className="absolute z-10 grid transition-all rounded-lg opacity-0 place-items-center size-full bg-mainAccent/40 group-hover:opacity-100">

--- a/src/routes/anime/$animeId/-Episodes.tsx
+++ b/src/routes/anime/$animeId/-Episodes.tsx
@@ -60,10 +60,8 @@ export default function Episodes({
   }
 
   return (
-    <div className="flex flex-col px-24 pt-8 pb-10 space-y-6 text-gray-400">
-      <div className="flex justify-between">
-        <p className="text-2xl font-semibold">Episodes</p>
-      </div>
+    <div className="flex flex-col px-3 pt-8 pb-16 space-y-6 text-gray-400 sm:px-5 md:px-8 lg:px-12 xl:px-16">
+      <p className="font-semibold text-lg lg:text-xl text-[#f6f4f4]">Episodes</p>
       <div className="self-center py-12 text-xl">No Episodes available</div>
     </div>
   );

--- a/src/routes/anime/-AnimeCard.tsx
+++ b/src/routes/anime/-AnimeCard.tsx
@@ -1,11 +1,13 @@
-import { Anime } from "../../utils/types/animeAnilist";
+import { Anime, Status } from "../../utils/types/animeAnilist";
 import { Link } from "@tanstack/react-router";
+import { cn } from "@/lib/utils";
 
 type AnimeCardProps = {
   anime: Anime;
+  className?: string;
 };
 
-export default function AnimeCard({ anime }: AnimeCardProps) {
+export default function AnimeCard({ anime, className }: AnimeCardProps) {
   return (
     <Link
       to="/anime/$animeId"
@@ -24,10 +26,15 @@ export default function AnimeCard({ anime }: AnimeCardProps) {
         },
       }}
     >
-      <div className="relative aspect-[3/4] overflow-hidden bg-gray-600 rounded-xl">
+      <div
+        className={cn(
+          "relative aspect-[3/4] overflow-hidden bg-gray-600 rounded-md lg:rounded-xl",
+          className
+        )}
+      >
         {anime.image && (
           <>
-            <div className="absolute z-10 grid transition-all opacity-0 place-items-center size-full bg-mainAccent/40 group-hover:opacity-100">
+            <div className="absolute z-10 hidden transition-all opacity-0 lg:grid place-items-center size-full bg-mainAccent/40 group-hover:opacity-100">
               <div className="grid bg-white rounded-full size-12 place-items-center">
                 <svg
                   className="size-[50%]"
@@ -39,7 +46,6 @@ export default function AnimeCard({ anime }: AnimeCardProps) {
                 </svg>
               </div>
             </div>
-            {/* <div className="absolute z-10 transition-all opacity-0 size-full bg-gradient-to-t from-mainAccent/50 to-transparent from-[percentage:0%_1%] group-hover:opacity-100"></div> */}
             <img
               loading="lazy"
               src={anime.image}
@@ -49,14 +55,33 @@ export default function AnimeCard({ anime }: AnimeCardProps) {
           </>
         )}
       </div>
-      <div>
-        <p className="text-sm font-medium text-[#E0E0E0] line-clamp-1">
-          {anime.title.english}
+      <div className="space-y-1">
+        <p className="text-sm font-medium text-[#E0E0E0] line-clamp-2">
+          {anime.title.english ?? anime.title.romaji}
         </p>
         <div className="flex items-center gap-2 text-xs text-gray-400">
-          <p>{anime.releaseDate}</p>
-          <div className="bg-gray-400 rounded-full size-1"></div>
-          <p>{anime.totalEpisodes} episodes</p>
+          {anime.status === Status.NotYetAired ? (
+            <p className="line-clamp-1">Not yet aired</p>
+          ) : (
+            <>
+              <p>{anime.releaseDate}</p>
+              <div className="bg-gray-400 rounded-full size-1"></div>
+              {anime.type === "MOVIE" ? (
+                <p className="line-clamp-1">MOVIE</p>
+              ) : (
+                <>
+                  <p className="line-clamp-1 lg:hidden">
+                    {anime.totalEpisodes}{" "}
+                    {anime.totalEpisodes === 1 ? "ep" : "eps"}
+                  </p>
+                  <p className="hidden line-clamp-1 lg:block">
+                    {anime.totalEpisodes}{" "}
+                    {anime.totalEpisodes === 1 ? "episode" : "episodes"}
+                  </p>
+                </>
+              )}
+            </>
+          )}
         </div>
       </div>
     </Link>

--- a/src/routes/anime/-AnimeCategoryCarousel.tsx
+++ b/src/routes/anime/-AnimeCategoryCarousel.tsx
@@ -1,0 +1,53 @@
+import { ChevronRight } from "lucide-react";
+import { Anime } from "@/utils/types/animeAnilist";
+import { Link } from "@tanstack/react-router";
+import AnimeCard from "./-AnimeCard";
+import {
+  Carousel,
+  CarouselContent,
+  CarouselItem,
+  CarouselNext,
+  CarouselPrevious,
+} from "@/components/ui/custom-carousel";
+
+type AnimeCategoryCarouselProps = {
+  animeList: Anime[];
+  categoryName: string;
+};
+
+export default function AnimeCategoryCarousel({
+  animeList,
+  categoryName,
+}: AnimeCategoryCarouselProps) {
+
+  return (
+    <div className="w-full px-3 pt-5 space-y-6 text-gray-400 lg:px-24 sm:px-6">
+      <div className="flex justify-between w-full">
+        <p className="text-lg font-semibold sm:text-xl lg:text-2xl">{categoryName}</p>
+        <Link className="flex items-center gap-1 px-2 py-1 transition-all duration-300 border border-gray-400 rounded-full sm:px-3 sm:py-2 lg:px-4 group hover:border-mainAccent">
+          <p className="text-xs transition-all duration-300 md:text-base group-hover:text-mainAccent whitespace-nowrap">
+            See All
+          </p>
+          <ChevronRight className="transition-colors duration-300 size-4 md:size-5 lg:size-6 group-hover:stroke-mainAccent" />
+        </Link>
+      </div>
+
+      <Carousel opts={{
+        slidesToScroll: 3,
+        dragFree: true
+      }} className="w-full">
+        <CarouselContent className="">
+          {animeList.map((anime) => {
+            return (
+              <CarouselItem key={anime.id} className="basis-1/3 mobile-m:basis-[30%] 570:basis-1/4 sm:basis-1/5 xl:basis-1/6">
+                <AnimeCard key={anime.id} anime={anime} className="min-h-fit max-h-[250px]"/>
+              </CarouselItem>
+            );
+          })}
+        </CarouselContent>
+        <CarouselPrevious carouselType="category-carousel" className="absolute left-0 border-none bg-gradient-to-r from-darkBg from-10% via-darkBg/80 via-50% to-transparent" />
+        <CarouselNext carouselType="category-carousel" className="absolute right-0 border-none bg-gradient-to-l from-darkBg from-10% via-darkBg/80 via-50% to-transparent" />
+      </Carousel>
+    </div>
+  );
+}

--- a/src/routes/anime/-AnimeCategorySection.tsx
+++ b/src/routes/anime/-AnimeCategorySection.tsx
@@ -11,7 +11,7 @@ type AnimeCategorySectionProps = {
 export default function AnimeCategorySection({ animeList, categoryName }: AnimeCategorySectionProps) {
 
     return (
-    <div className="w-full px-24 pt-5 mx-auto space-y-6 text-gray-400">
+    <div className="w-full px-24 pt-5 space-y-6 text-gray-400">
       <div className="flex justify-between">
         <p className="text-2xl font-semibold">{categoryName}</p>
         <Link className="flex items-center gap-3 py-2 pl-4 pr-3 transition-all duration-300 border border-gray-400 rounded-full group hover:border-mainAccent">

--- a/src/routes/anime/-AnimeHeroComponent.tsx
+++ b/src/routes/anime/-AnimeHeroComponent.tsx
@@ -57,8 +57,8 @@ export default function AnimeHeroComponent({
 
   return (
     <div className="relative flex justify-center w-full text-sm md:text-base">
-      <div className="absolute inset-0 w-dvw left-1/2 ml-[-50vw] max-h-[600px]">
-        <div className="absolute bg-black/60 size-full backdrop-blur-sm"></div>
+      <div className="absolute inset-0 w-dvw left-1/2 ml-[-50vw] max-h-[500px] md:max-h-[600px]">
+        <div className="absolute bg-black/60 size-full backdrop-blur-[2px]"></div>
         <div className="absolute bg-gradient-to-t from-darkBg from-[percentage:0%_1%] via-transparent to-transparent size-full"></div>
         <img src={cover ?? image} className="object-cover size-full" />
       </div>

--- a/src/routes/anime/-TrendingAnimesHeroCarousel.tsx
+++ b/src/routes/anime/-TrendingAnimesHeroCarousel.tsx
@@ -4,7 +4,7 @@ import {
   CarouselItem,
   CarouselNext,
   CarouselPrevious,
-} from "@/components/ui/anime-carousel";
+} from "@/components/ui/custom-carousel";
 import { Anime } from "../../utils/types/animeAnilist";
 import TrendingCarouselItem from "./-TrendingCarouselItem";
 
@@ -20,7 +20,10 @@ export default function TrendingAnimesHeroCarousel({
       <CarouselContent>
         {animeList.map((anime, i) => {
           return (
-            <CarouselItem key={i} className="relative w-full">
+            <CarouselItem
+              key={i}
+              className="relative w-full h-[380px] mobile-l:h-[400px] sm:h-[420px] md:h-[450px] lg:h-[500px] xl:h-[525px]"
+            >
               <TrendingCarouselItem
                 genres={anime.genres}
                 image={anime.image}
@@ -31,20 +34,20 @@ export default function TrendingAnimesHeroCarousel({
                 trendingRank={i + 1}
                 type={anime.type}
               />
-              <div className="absolute inset-0 w-dvw left-1/2 ml-[-50vw]">
-                <div className="absolute bg-black/60 size-full backdrop-blur-sm"></div>
-                <div className="absolute bg-gradient-to-t from-darkBg from-[percentage:0%_1%] via-transparent to-transparent size-full"></div>
+              <div className="absolute inset-0 w-full left-1/2 ml-[-50vw] h-full">
+                <div className="absolute bg-black/60 size-full backdrop-blur-[1px]"></div>
+                <div className="absolute bg-gradient-to-t from-darkBg from-0% to-transparent to-80% size-full"></div>
                 <img
                   src={anime.cover ?? anime.image}
-                  className="object-cover size-full"
+                  className="object-cover object-center size-full"
                 />
               </div>
             </CarouselItem>
           );
         })}
       </CarouselContent>
-      <CarouselPrevious className="absolute left-0 ml-5 border-none bg-black/40 hover:bg-mainAccent" />
-      <CarouselNext className="absolute right-0 mr-5 border-none bg-black/40 hover:bg-mainAccent" />
+      <CarouselPrevious carouselType="hero-carousel" className="absolute left-0 ml-2 border-none md:ml-5 xl:ml-6 bg-black/40 hover:bg-mainAccent" />
+      <CarouselNext carouselType="hero-carousel" className="absolute right-0 mr-2 border-none md:mr-5 xl:mr-6 bg-black/40 hover:bg-mainAccent" />
     </Carousel>
   );
 }

--- a/src/routes/anime/-TrendingCarouselItem.tsx
+++ b/src/routes/anime/-TrendingCarouselItem.tsx
@@ -27,39 +27,29 @@ export default function TrendingCarouselItem({
   const navigate = useNavigate();
 
   return (
-    <div className="flex justify-center w-full h-[80dvh] max-h-[600px] items-center pt-20">
-      <div className="relative flex justify-center w-[1440px] px-24">
-        <div className="flex items-center w-full gap-16">
-          <div className="aspect-[3/4] h-[300px] rounded-xl overflow-hidden z-10">
+    <div className="flex items-end justify-center lg:items-center size-full lg:pt-20">
+      <div className="relative flex justify-center w-full lg:w-[1440px] lg:px-16 xl:px-24 px-3 sm:px-6">
+        <div className="flex w-full gap-16">
+          <div className="aspect-[3/4] h-[300px] rounded-xl overflow-hidden z-10 lg:block hidden">
             <img src={image} className="object-cover size-full" />
           </div>
-          <div className="relative z-10 flex-1">
-            <div className="relative flex flex-col w-[70%] gap-4">
-              <p className="text-lg">
-                <span className="text-2xl font-bold text-mainAccent">
-                  #{trendingRank}
-                </span>{" "}
-                in trending
-              </p>
-              <p className="text-3xl font-bold">{title}</p>
-              <p className="text-gray-400 line-clamp-3">
+          <div className="z-10 flex-1">
+            <div className="flex flex-col sm:w-[80%] xl:w-[70%] gap-4">
+              <div className="space-y-3">
+                <p className="mb-auto text-lg">
+                  <span className="text-2xl font-bold text-mainAccent">
+                    #{trendingRank}
+                  </span>{" "}
+                  in trending
+                </p>
+                <h1 className="text-xl font-bold sm:text-2xl md:text-3xl line-clamp-2">
+                  {title}
+                </h1>
+              </div>
+              <p className="hidden text-gray-400 lg:line-clamp-3">
                 {`${description ? description.replace(/<[^>]*>/g, "") : "No Description"}`}
-                {/* <div className="flex text-lg">
-                  {genres.map((genre, i) => {
-                    return (
-                      <div
-                        className={`flex items-center text-gray-400 gap-2 ${i !== 0 ? "ml-2" : ""}`}
-                      >
-                        <p>{genre}</p>
-                        {i !== genres.length - 1 && (
-                          <div className="bg-gray-400 rounded-full size-1"></div>
-                        )}
-                      </div>
-                    );
-                  })}
-                </div> */}
               </p>
-              <div className="flex gap-5 my-4">
+              <div className="flex gap-2 sm:gap-4 sm:my-4">
                 <motion.button
                   whileHover={{ scale: 1.03 }}
                   transition={{ duration: 0.2 }}
@@ -81,18 +71,18 @@ export default function TrendingCarouselItem({
                       },
                     });
                   }}
-                  className="flex items-center gap-2 px-5 py-2 rounded-full bg-mainAccent"
+                  className="flex items-center gap-1 px-3 py-2 rounded-full sm:gap-2 mobile-l:px-4 sm:px-5 bg-mainAccent"
                 >
                   <Play size={20} />
-                  <p className="font-medium">Play Now</p>
+                  <p className="text-sm font-medium sm:text-base">Play Now</p>
                 </motion.button>
                 <motion.button
                   whileHover={{ scale: 1.03 }}
                   transition={{ duration: 0.2 }}
-                  className="flex items-center gap-2 px-5 py-2 bg-black rounded-full"
+                  className="flex items-center gap-1 px-3 py-2 bg-black rounded-full sm:gap-2 mobile-l:px-4 sm:px-5"
                 >
                   <Bookmark size={20} />
-                  <p className="font-medium">Add to List</p>
+                  <p className="text-sm font-medium sm:text-base">Add to List</p>
                 </motion.button>
               </div>
             </div>

--- a/src/routes/anime/index.tsx
+++ b/src/routes/anime/index.tsx
@@ -6,6 +6,7 @@ import {
 } from "../../api/animes";
 import TrendingAnimesHeroCarousel from "./-TrendingAnimesHeroCarousel";
 import AnimeCategorySection from "./-AnimeCategorySection";
+import AnimeCategoryCarousel from "./-AnimeCategoryCarousel";
 
 export const Route = createFileRoute("/anime/")({
   component: () => <Home />,
@@ -43,16 +44,16 @@ function Home() {
             animeList={trendingAnimes.results.slice(0, 5)}
           />
         </div>
-        <div className="pb-24 space-y-10">
-          <AnimeCategorySection
-            animeList={trendingAnimes.results.slice(5)}
+        <div className="w-full pt-8 pb-24 space-y-10">
+          <AnimeCategoryCarousel
+            animeList={trendingAnimes.results.slice(3)}
             categoryName="Trending Anime"
           />
-          <AnimeCategorySection
+          <AnimeCategoryCarousel
             animeList={topRatedAnimes.results}
-            categoryName="Top Rated Anime"
+            categoryName="Top Rated"
           />
-          <AnimeCategorySection
+          <AnimeCategoryCarousel
             animeList={popularAnimes.results}
             categoryName="All Time Popular"
           />

--- a/src/utils/types/animeAnilist.ts
+++ b/src/utils/types/animeAnilist.ts
@@ -175,6 +175,7 @@ export type Recommendation = {
 export enum Status {
   Completed = "Completed",
   Ongoing = "Ongoing",
+  NotYetAired  = "Not yet aired"
 }
 
 export type Relation = {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -23,7 +23,7 @@ module.exports = {
       screens: {
         "mobile-m" : "375px",
         "mobile-l" : "425px",
-        
+        "570": "570px"
       },
       colors: {
         darkBg: '#100c14',


### PR DESCRIPTION
In this PR I:

- implemented responsiveness for anime homepage
- replaced AnimeCategorySection with custom carousel called AnimeCategoryCarousel
- changed anime-carousel.tsx name to custom-carousel.tsx
- modified custom-carousel carouselprevious & carouselnext buttons to receive carouseltype props, to render different next and previous buttons for the TrendingHeroCarousel and AnimeCategoryCarousel, since they both use custom-carousel.tsx
- added classname prop and cn function for AnimeCard classname
- reduced backdrop-blur of the backdrop image of  AniimeHeroComponent (to backdrop-blur-2px) and TrendingAnimeHeroCarousel (to backdrop-blur-1px)
- added Not yet aired to Status type in animeAnilist.ts
- changed AnimeCard to show x eps instead of episodes in 1024px or below screen width